### PR TITLE
Extend terminology DuckDB workflows

### DIFF
--- a/docs/simulator_pivot_next_steps.md
+++ b/docs/simulator_pivot_next_steps.md
@@ -20,6 +20,8 @@ This checklist captures the outstanding tasks to complete the simulator-first re
 - 🔄 Populate terminology datasets with comprehensive NLM/NCBI extracts (pending larger import tooling).
 - 🔄 Enrich terminology integration (e.g., map RxNorm CUIs to clinical scenarios, extend exporters) now that normalized tables exist for all vocabularies.
 - 🔄 Design a DuckDB terminology warehouse (schema, ingestion jobs) to ingest normalized ICD-10/LOINC/SNOMED/RxNorm tables; (build script and loader integration in progress—extend to VSAC/UMLS + document usage in pipeline).
+  - ✅ `tools/build_terminology_db.py` now stages VSAC value sets and UMLS concepts and documents the DuckDB rebuild cadence.
+  - 🔄 Author import utilities for VSAC/UMLS so normalized CSVs can be generated alongside the existing ICD-10/LOINC/SNOMED/RxNorm helpers.
 - Expand FHIR/CSV exporters to consume the new terminology services.
 
 ## Phase 3 – Clinical Realism & Validation

--- a/implementation.md
+++ b/implementation.md
@@ -9,8 +9,9 @@ This document captures the current state and near-term priorities for the simula
 
 ## Immediate Next Steps
 1. **Extend terminology DuckDB workflows**
-   - Add VSAC/UMLS staging to `tools/build_terminology_db.py` and decide how/when to regenerate the database (CLI flag, build step, documentation).
-   - Document `TERMINOLOGY_DB_PATH` usage and incorporate the warehouse into developer onboarding.
+   - ✅ VSAC/UMLS staging added to `tools/build_terminology_db.py` alongside a `--force` rebuild guard.
+   - ✅ DuckDB onboarding guidance (`TERMINOLOGY_DB_PATH`, regeneration cadence) folded into the main README and terminology docs.
+   - 🔄 Automate normalization for VSAC/UMLS drops (dedicated import scripts or documented ETL steps) so staging isn't manual.
 2. **Prepare for Phase 3 clinical realism**
    - Once the vocabularies are in DuckDB, outline the clinical rules that ensure realistic condition/med/lab combinations (e.g., contraindications, age-appropriate labs).
 

--- a/tests/test_build_terminology_db.py
+++ b/tests/test_build_terminology_db.py
@@ -1,0 +1,76 @@
+"""Tests for the DuckDB terminology warehouse builder."""
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+
+import duckdb
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tools.build_terminology_db import build_database
+
+
+def _write_csv(path: Path, header: list[str], rows: list[list[str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+def _seed_minimal_terminology(root: Path) -> None:
+    _write_csv(
+        root / "icd10/icd10_conditions.csv",
+        ["code", "description", "chapter", "ncbi_url"],
+        [["A00", "Cholera", "Certain infectious and parasitic diseases", "https://ncbi.example/A00"]],
+    )
+    _write_csv(
+        root / "loinc/loinc_labs.csv",
+        ["loinc_code", "long_common_name", "component", "property", "system", "ncbi_url"],
+        [["1234-5", "Glucose [Mass/volume] in Blood", "Glucose", "MCnc", "Bld", "https://ncbi.example/loinc"]],
+    )
+    _write_csv(
+        root / "snomed/snomed_conditions.csv",
+        ["snomed_id", "pt_name", "icd10_mapping", "ncbi_url"],
+        [["123456", "Diabetes mellitus", "E11", "https://ncbi.example/snomed"]],
+    )
+    _write_csv(
+        root / "rxnorm/rxnorm_medications.csv",
+        ["rxnorm_cui", "tty", "ingredient_name", "ndc_example", "ncbi_url"],
+        [["12345", "IN", "Metformin", "00000-0000", "https://ncbi.example/rxnorm"]],
+    )
+
+
+def test_build_creates_optional_tables_when_missing(tmp_path: Path) -> None:
+    root = tmp_path / "terminology"
+    _seed_minimal_terminology(root)
+    output = root / "terminology.duckdb"
+
+    build_database(root, output, force=True)
+
+    con = duckdb.connect(str(output))
+    try:
+        tables = {row[0] for row in con.execute("SHOW TABLES").fetchall()}
+        assert "vsac_value_sets" in tables
+        assert "umls_concepts" in tables
+        vsac_count = con.execute("SELECT COUNT(*) FROM vsac_value_sets").fetchone()[0]
+        umls_count = con.execute("SELECT COUNT(*) FROM umls_concepts").fetchone()[0]
+    finally:
+        con.close()
+
+    assert vsac_count == 0
+    assert umls_count == 0
+
+
+def test_build_requires_force_when_database_exists(tmp_path: Path) -> None:
+    root = tmp_path / "terminology"
+    _seed_minimal_terminology(root)
+    output = root / "terminology.duckdb"
+
+    build_database(root, output, force=True)
+
+    with pytest.raises(SystemExit):
+        build_database(root, output)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,5 @@
+"""Utility scripts for terminology and simulator tooling."""
+
+from .build_terminology_db import build_database
+
+__all__ = ["build_database"]


### PR DESCRIPTION
## Summary
- add VSAC and UMLS table loaders to the DuckDB terminology builder with a force overwrite guard
- document warehouse regeneration and `TERMINOLOGY_DB_PATH` setup in onboarding guides and roadmap files
- add coverage for the builder, including optional table creation and overwrite enforcement

## Testing
- pytest tests/test_build_terminology_db.py

------
https://chatgpt.com/codex/tasks/task_e_68d6119ef310832f86949aab2999f70b